### PR TITLE
Fix requirements, add packaging

### DIFF
--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,1 +1,2 @@
 google-api-python-client
+packaging


### PR DESCRIPTION
Fixes missing dependency for (at least) Python 3.12.

### Background

Installed this plugin on Dataiku Cloud in a Python 3.12 Code Env but wasn't able to run due to the following error:
`ModuleNotFoundError: No module named 'packaging'`.

<details>
<summary>Full stack trace</summary>

```
2025-11-03 07:49:01,751 1529572 INFO [Child] opened stderr
2025-11-03 07:49:01,752 1529572 INFO [Child] about to close other fd
2025-11-03 07:49:01,752 1529572 INFO [Child] closed other fd
2025-11-03 07:49:01,752 1529572 INFO [Child] chdired
2025-11-03 07:49:01,752 1529572 INFO setting username=dssuser_richard_d756a5ca uid=10001 gid=10000
2025-11-03 07:49:01,754 1529572 INFO [Child] dropped privileges
2025-11-03 07:49:01,754 1529572 INFO [Child] Checking access to DKUINSTALLDIR and DIP_HOME directories
2025-11-03 07:49:01,754 1529572 INFO [Child] Executing: /data/dataiku/datadir/code-envs/python/plugin_google-search-tool_managed/bin/python : /data/dataiku/datadir/code-envs/python/plugin_google-search-tool_managed/bin/python -u -u -m dataiku.llm.agent_tools.server 32825 64DDTIvSOFsvTNoS
WARNING:root:Could not import pandas. Pandas support will be disabled. To enable get_dataframe and other methods, please install the pandas package
Installing debugging signal handler
<frozen importlib._bootstrap>:530: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
ERROR:dataiku.base.async_link:Error while handling request
Traceback (most recent call last):
  File "/home/dataiku/dataiku-dss-14.1.4/python/dataiku/base/async_link.py", line 352, in handle_request
    async for response_payload in self.handler(request_payload):
  File "/home/dataiku/dataiku-dss-14.1.4/python/dataiku/llm/agent_tools/server.py", line 52, in handler
    yield await asyncio.get_running_loop().run_in_executor(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dataiku/dataiku-dss-14.1.4/python/dataiku/llm/agent_tools/server.py", line 80, in start
    clazz = get_clazz_in_code(code, BaseAgentTool, strict_module=True)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dataiku/dataiku-dss-14.1.4/python/dataiku/base/utils.py", line 36, in get_clazz_in_code
    module = ImpCompat.load_source(
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dataiku/dataiku-dss-14.1.4/python/dataiku/base/compat.py", line 12, in load_source
    return ImpCompat._importlib_load_source(name, filename)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dataiku/dataiku-dss-14.1.4/python/dataiku/base/compat.py", line 55, in _importlib_load_source
    return SourceFileLoader(name, filename).load_module()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap_external>", line 653, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 1180, in load_module
  File "<frozen importlib._bootstrap_external>", line 1004, in load_module
  File "<frozen importlib._bootstrap>", line 537, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 966, in _load
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/tmp/tmp_folder_BsTnaYpm/dku_code.py", line 3, in <module>
  File "/data/dataiku/datadir/code-envs/python/plugin_google-search-tool_managed/lib/python3.12/site-packages/googleapiclient/discovery.py", line 42, in <module>
    import google.api_core.client_options
  File "/data/dataiku/datadir/code-envs/python/plugin_google-search-tool_managed/lib/python3.12/site-packages/google/api_core/__init__.py", line 20, in <module>
    from google.api_core import _python_package_support
  File "/data/dataiku/datadir/code-envs/python/plugin_google-search-tool_managed/lib/python3.12/site-packages/google/api_core/_python_package_support.py", line 28, in <module>
    from packaging.version import parse as parse_version
ModuleNotFoundError: No module named 'packaging'
``` 

</summary>